### PR TITLE
Update RNSyanImagePicker.m

### DIFF
--- a/ios/RNSyanImagePicker.m
+++ b/ios/RNSyanImagePicker.m
@@ -341,6 +341,11 @@ RCT_EXPORT_METHOD(removeAllPhoto) {
     }
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+   return YES;
+}
+
 - (BOOL)createDir {
     NSString * path = [NSString stringWithFormat:@"%@ImageCaches", NSTemporaryDirectory()];;
     NSFileManager *fileManager = [NSFileManager defaultManager];


### PR DESCRIPTION
Module RNSyanImagePicker requires main queue setup since it overrides `init` but doesn't implement `requiresMainQueueSetup`.