### PR TITLE
修复podspec文件package.json路径不对导致pod install无法安装

### DIFF
--- a/ios/RNSyanImagePicker.podspec
+++ b/ios/RNSyanImagePicker.podspec
@@ -1,5 +1,5 @@
 require 'json'
-package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+package = JSON.parse(File.read(File.join(__dir__, '../package.json')))
 
 Pod::Spec.new do |s|
   s.name            = "RNSyanImagePicker"


### PR DESCRIPTION
podspec文件内的package.json文件路径不对~