### PR TITLE
Delete file_paths.xml

### DIFF
--- a/android/src/main/res/xml/file_paths.xml
+++ b/android/src/main/res/xml/file_paths.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <paths>
-        <external-path
-            name="camera_photos"
-            path="" />
-    </paths>
-</resources>


### PR DESCRIPTION
此文件格式错误（多出`<resources>`父节点），会覆盖其他第三方的同名文件设置。而且既然没有直接使用，不如整个删掉好。