### PR TITLE
增加compressFocusAlpha参数&修正返回的base64的前缀类型不正确问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ showCropCircle         | bool | 是      | false  | 是否显示圆形裁剪区�
 circleCropRadius         | float | 是      | screenW * 0.5  | 圆形裁剪半径，默认屏幕宽度一半
 showCropFrame         | bool | 是      | true  | 是否显示裁剪区域
 showCropGrid         | bool | 是      | false  | 是否隐藏裁剪区域网格
+compress        | bool | 是      | true  | 是否开启压缩（不开启压缩部分图片属性无法获得
+compressFocusAlpha        | bool | 是      | false  | 压缩时保留图片透明度（开启后png压缩后尺寸会变大但是透明度会保留
 quality         | int | 是      | 90  | 压缩质量(安卓无效，固定鲁班压缩)
 minimumCompressSize | int | 是 | 100 | 小于100kb的图片不压缩（Android）
 enableBase64        | bool | 是      | false  | 是否返回base64编码，默认不返回

--- a/android/src/main/java/com/syanpicker/RNSyanImagePickerModule.java
+++ b/android/src/main/java/com/syanpicker/RNSyanImagePickerModule.java
@@ -165,6 +165,7 @@ public class RNSyanImagePickerModule extends ReactContextBaseJavaModule {
         int quality = this.cameraOptions.getInt("quality");
         boolean isWeChatStyle = this.cameraOptions.getBoolean("isWeChatStyle");
         boolean showSelectedIndex = this.cameraOptions.getBoolean("showSelectedIndex");
+        boolean compressFocusAlpha = this.cameraOptions.getBoolean("compressFocusAlpha");
 
         int modeValue;
         if (imageCount == 1) {
@@ -209,6 +210,7 @@ public class RNSyanImagePickerModule extends ReactContextBaseJavaModule {
                 .selectionMedia(selectList) // 当前已选中的图片 List
                 .isWeChatStyle(isWeChatStyle)
                 .theme(showSelectedIndex ? R.style.picture_WeChat_style : 0)
+                .compressFocusAlpha(compressFocusAlpha)
                 .forResult(PictureConfig.CHOOSE_REQUEST); //结果回调onActivityResult code
     }
 
@@ -230,6 +232,7 @@ public class RNSyanImagePickerModule extends ReactContextBaseJavaModule {
         int quality = this.cameraOptions.getInt("quality");
         boolean isWeChatStyle = this.cameraOptions.getBoolean("isWeChatStyle");
         boolean showSelectedIndex = this.cameraOptions.getBoolean("showSelectedIndex");
+        boolean compressFocusAlpha = this.cameraOptions.getBoolean("compressFocusAlpha");
 
         Boolean isAndroidQ = SdkVersionUtils.checkedAndroid_Q();
 
@@ -255,6 +258,7 @@ public class RNSyanImagePickerModule extends ReactContextBaseJavaModule {
                 .scaleEnabled(scaleEnabled)// 裁剪是否可放大缩小图片 true or false
                 .isWeChatStyle(isWeChatStyle)
                 .theme(showSelectedIndex ? R.style.picture_WeChat_style : 0)
+                .compressFocusAlpha(compressFocusAlpha)
                 .forResult(PictureConfig.CHOOSE_REQUEST);//结果回调onActivityResult code
     }
 
@@ -396,7 +400,6 @@ public class RNSyanImagePickerModule extends ReactContextBaseJavaModule {
         if (media.isCut()) {
             path = media.getCutPath();
         }
-
         BitmapFactory.Options options = new BitmapFactory.Options();
         options.inJustDecodeBounds = true;
         BitmapFactory.decodeFile(path, options);

--- a/android/src/main/java/com/syanpicker/RNSyanImagePickerModule.java
+++ b/android/src/main/java/com/syanpicker/RNSyanImagePickerModule.java
@@ -445,6 +445,9 @@ public class RNSyanImagePickerModule extends ReactContextBaseJavaModule {
             e.printStackTrace();
         }
         bytes = output.toByteArray();
+        if(absoluteFilePath.toLowerCase().endsWith("png")){
+          return "data:image/png;base64," + Base64.encodeToString(bytes, Base64.NO_WRAP);
+        }
         return "data:image/jpeg;base64," + Base64.encodeToString(bytes, Base64.NO_WRAP);
     }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,6 +15,7 @@ export interface ImagePickerOption {
     rotateEnabled: boolean,       // 裁剪是否可旋转图片
     scaleEnabled: boolean,        // 裁剪是否可放大缩小图片
     compress: boolean,
+    compressFocusAlpha:boolean,   //压缩png保留通明度
     minimumCompressSize: number,  // 小于100kb的图片不压缩
     quality: number,               // 压缩质量
     enableBase64: boolean,       // 是否返回base64编码，默认不返回

--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ const defaultOptions = {
     rotateEnabled: true,       // 裁剪是否可旋转图片
     scaleEnabled: true,        // 裁剪是否可放大缩小图片
     compress: true,
+    compressFocusAlpha:false,   //压缩png保留通明度
     minimumCompressSize: 100,  // 小于100kb的图片不压缩
     quality: 90,               // 压缩质量
     enableBase64: false,       // 是否返回base64编码，默认不返回

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 
 {
   "name": "react-native-syan-image-picker",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "description": "React-Native 多图片选择 支持裁剪 压缩",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
安卓目前带透明度的png启用压缩会造成黑底，所以增加了一个是否开启透明度的选项。
IOS目前使用的png压缩库UIImagePNGRepresentation压缩率有很大问题，后期推荐改成压缩率更好得库比如：pngquant